### PR TITLE
SA Mobile GXT support

### DIFF
--- a/GXT Builder/gxtbuild.cpp
+++ b/GXT Builder/gxtbuild.cpp
@@ -253,7 +253,7 @@ void ParseCharacterMap(const std::wstring& szFileName, wchar_t* pCharacterMap)
 		throw std::runtime_error( "Cannot parse character map file " + std::string(szFileName.begin(), szFileName.end()) + "!" );
 }
 
-void ParseINI( std::wstring strFileName, tableMap_t& TableMap, wchar_t* pCharacterMap, eGXTVersion fileVersion )
+void ParseINI( std::wstring strFileName, tableMap_t& TableMap, wchar_t* pCharacterMap, eGXTVersion& fileVersion )
 {
 	const size_t SCRATCH_PAD_SIZE = 32767;
 	WideDelimStringReader reader( SCRATCH_PAD_SIZE );

--- a/GXT Builder/gxtbuild.cpp
+++ b/GXT Builder/gxtbuild.cpp
@@ -137,13 +137,15 @@ namespace VC
 
 namespace SA
 {
-	bool GXTTable::InsertEntry( const std::string& entryName, uint32_t offset )
+	template<typename Character>
+	bool GXTTable<Character>::InsertEntry( const std::string& entryName, uint32_t offset )
 	{
 		uint32_t entryHash = crc32FromUpcaseString( entryName.c_str() );
 		return Entries.emplace( entryHash, static_cast<uint32_t>(offset * sizeof(character_t)) ).second != false;
 	}
 
-	void GXTTable::WriteOutEntries( std::ostream& stream )
+	template<typename Character>
+	void GXTTable<Character>::WriteOutEntries( std::ostream& stream )
 	{
 		for ( auto& it : Entries )
 		{
@@ -152,12 +154,14 @@ namespace SA
 		}
 	}
 
-	void GXTTable::WriteOutContent( std::ostream& stream )
+	template<typename Character>
+	void GXTTable<Character>::WriteOutContent( std::ostream& stream )
 	{
 		stream.write( reinterpret_cast<const char*>( FormattedContent.c_str() ), FormattedContent.size() * sizeof(character_t) );
 	}
 
-	void GXTTable::PushFormattedChar( int character )
+	template<typename Character>
+	void GXTTable<Character>::PushFormattedChar( int character )
 	{
 		FormattedContent.push_back( static_cast<character_t>( character ) );
 	}
@@ -172,7 +176,7 @@ std::unique_ptr<GXTFileBase> GXTFileBase::InstantiateBuilder( eGXTVersion versio
 		ptr = std::make_unique< VC::GXTFile >();
 		break;
 	case GXT_SA:
-		ptr = std::make_unique< SA::GXTFile >();
+		ptr = std::make_unique< SA::GXTFile<uint8_t> >();
 		break;
 	default:
 		throw std::runtime_error( std::string("Trying to instantiate an unsupported GXT builder version " + version) + "!" );
@@ -402,7 +406,7 @@ void ParseINI( std::wstring strFileName, tableMap_t& TableMap, wchar_t* pCharact
 				Table = std::make_unique<VC::GXTTable>( line ); 
 				break;
 			case GXT_SA:
-				Table = std::make_unique<SA::GXTTable>( line ); 
+				Table = std::make_unique<SA::GXTTable<uint8_t> >( line ); 
 				break;
 			}
 

--- a/GXT Builder/gxtbuild.cpp
+++ b/GXT Builder/gxtbuild.cpp
@@ -178,6 +178,9 @@ std::unique_ptr<GXTFileBase> GXTFileBase::InstantiateBuilder( eGXTVersion versio
 	case GXT_SA:
 		ptr = std::make_unique< SA::GXTFile<uint8_t> >();
 		break;
+	case GXT_SA_MOBILE:
+		ptr = std::make_unique< SA::GXTFile<uint16_t> >();
+		break;
 	default:
 		throw std::runtime_error( std::string("Trying to instantiate an unsupported GXT builder version " + version) + "!" );
 		break;
@@ -379,6 +382,8 @@ void ParseINI( std::wstring strFileName, tableMap_t& TableMap, wchar_t* pCharact
 				fileVersion = GXT_VC;
 			else if ( _wcsicmp( buf, L"sa" ) )
 				fileVersion = GXT_SA;
+			else if ( _wcsicmp( buf, L"samobile" ) )
+				fileVersion = GXT_SA_MOBILE;
 		}
 	}
 
@@ -407,6 +412,9 @@ void ParseINI( std::wstring strFileName, tableMap_t& TableMap, wchar_t* pCharact
 				break;
 			case GXT_SA:
 				Table = std::make_unique<SA::GXTTable<uint8_t> >( line ); 
+				break;
+			case GXT_SA_MOBILE:
+				Table = std::make_unique<SA::GXTTable<uint16_t> >( line );
 				break;
 			}
 
@@ -654,6 +662,8 @@ const wchar_t* GetFormatName( eGXTVersion version )
 		return L"GTA Vice City";
 	case GXT_SA:
 		return L"GTA San Andreas";
+	case GXT_SA_MOBILE:
+		return L"GTA San Andreas (Mobile version)";
 	}
 	return L"Unsupported";
 }
@@ -708,6 +718,8 @@ int wmain(int argc, wchar_t* argv[])
 					fileVersion = GXT_SA;
 				else if ( tmp == L"-vc" )
 					fileVersion = GXT_VC;
+				else if ( tmp == L"-samobile" )
+					fileVersion = GXT_SA_MOBILE;
 			}
 			else
 				break;

--- a/GXT Builder/gxtbuild.h
+++ b/GXT Builder/gxtbuild.h
@@ -129,10 +129,11 @@ namespace VC
 
 namespace SA
 {
+	template<typename Character>
 	class GXTTable : public GXTTableBase
 	{
 	public:
-		typedef uint8_t character_t;
+		typedef Character character_t;
 
 		GXTTable( std:: wstring szFilePath )
 			: GXTTableBase( std::move(szFilePath) )
@@ -163,12 +164,13 @@ namespace SA
 		std::basic_string<character_t>	FormattedContent;
 	};
 
+	template<typename Character>
 	class GXTFile : public GXTFileBase
 	{
 	private:
 		virtual uint32_t WriteOutHeader( std::ostream& stream ) const override
 		{
-			const char		header[] = { 0x04, 0x00, sizeof(GXTTable::character_t) * 8, 0x00 };	// 0x080004
+			const char		header[] = { 0x04, 0x00, sizeof(GXTTable<typename Character>::character_t) * 8, 0x00 };	// 0x080004
 			stream.write(header, sizeof(header));
 			return sizeof(header);
 		}

--- a/GXT Builder/gxtbuild.h
+++ b/GXT Builder/gxtbuild.h
@@ -10,7 +10,8 @@ enum eGXTVersion
 {
 	GXT_III,	// Unsupported
 	GXT_VC,
-	GXT_SA
+	GXT_SA,
+	GXT_SA_MOBILE
 };
 
 class GXTTableBase


### PR DESCRIPTION
This refactors the code a bit to allow for building SA Mobile GXTs (SA format + utf-16 characters). Changes should also make supporting III GXT building easier.